### PR TITLE
:sparkles: feat: add Picture in Picture support with fragment management

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,3 +41,7 @@ android {
     abortOnError false
   }
 }
+
+dependencies {
+    implementation 'androidx.fragment:fragment-ktx:1.8.9'
+}

--- a/android/src/main/java/expo/modules/pip/PictureInPictureHelperFragment.kt
+++ b/android/src/main/java/expo/modules/pip/PictureInPictureHelperFragment.kt
@@ -1,0 +1,25 @@
+package expo.modules.pip
+
+import androidx.fragment.app.Fragment
+
+
+class PictureInPictureHelperFragment: Fragment() {
+    private var listener:PictureInPictureHelperListener? = null
+
+    fun setListener(listener: PictureInPictureHelperListener){
+        this.listener = listener
+    }
+
+    override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode)
+        listener?.onPictureInPictureModeChange(isInPictureInPictureMode)
+    }
+
+    companion object {
+        val id = "${PictureInPictureHelperFragment::class.java.simpleName}"
+    }
+}
+
+interface PictureInPictureHelperListener {
+     fun onPictureInPictureModeChange(isInPictureInPictureMode: Boolean)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expo-pip",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expo-pip",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "~18.3.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-pip",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A library that provides access to Picture In Picture API for Android only",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
- Add support for [onPictureInPictureModeChanged](https://developer.android.com/develop/ui/views/picture-in-picture?hl=en#handling_ui) instead of OnActivityEntersForeground and OnActivityEntersBackground.